### PR TITLE
Downgrade Steam User Lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,3 +325,9 @@ CSGOFloat config file location
 ### `-s`/`--steam_data` (default [node-steam-user config directory](https://github.com/DoctorMcKay/node-steam-user#datadirectory))
 
 node-steam-user config directory
+
+# Building New Docker Image
+Run this command to build multi-arch image. You have to be logged in the ECR
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t 028739291296.dkr.ecr.eu-central-1.amazonaws.com/float-service-prod:latest . --push
+```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "simple-vdf": "^1.1.1",
     "socket.io": "^2.4.0",
     "steam-totp": "^2.1.2",
-    "steam-user": "^4.28.1",
+    "steam-user": "4.27.1",
     "winston": "^2.4.5"
   },
   "devDependencies": {


### PR DESCRIPTION
The new version of steam-user (4.28) is broken. Therefore, we need to downgrade tp 4.21.1